### PR TITLE
refactor: Move remote device service ssh tunneling artifacts to new example repo

### DIFF
--- a/security/remote_devices/ssh-tunneling/Dockerfile-primary-ds-proxy
+++ b/security/remote_devices/ssh-tunneling/Dockerfile-primary-ds-proxy
@@ -1,0 +1,43 @@
+#  ----------------------------------------------------------------------------------
+#  Copyright 2020 Intel Corp.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+FROM alpine:latest
+
+# tunneling host name or ip
+ARG TUNNEL_HOST
+
+# ssh port in use, set this number if it is not the usually port 22 
+# or there is a different ssh port mapping between local and remote
+ARG TUNNEL_SSH_PORT
+
+# port number of service to forward
+ARG SERVICE_PORT
+
+# remote sshd host name or ip address for services to listen on ssh tunneling
+ARG SERVICE_HOST
+
+RUN apk add --update dumb-init openssh-client && rm -rf /var/cache/apk/*
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/entrypoint.sh /
+
+ENV APP_PORT=49990
+EXPOSE $APP_PORT $SERVICE_PORT $TUNNEL_SSH_PORT
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/security/remote_devices/ssh-tunneling/Dockerfile-remote-sshd
+++ b/security/remote_devices/ssh-tunneling/Dockerfile-remote-sshd
@@ -1,0 +1,43 @@
+#  ----------------------------------------------------------------------------------
+#  Copyright 2020 Intel Corp.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+FROM ubuntu:16.04
+
+ARG SSH_PUBLIC_KEY
+
+
+RUN apt-get update && apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN echo 'root:THEPASSWORDYOUCREATED' | chpasswd
+
+# pam_loginuid is used to set the loginuid audit attribute of a process when a user login through SSH
+# see the reference in https://stackoverflow.com/questions/21391142/why-is-it-needed-to-set-pam-loginuid-to-its-optional-value-with-docker
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# Allow the openssh client to specify IP address from which connections to the port are allowed
+RUN echo 'GatewayPorts clientspecified' >> /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+RUN mkdir /root/.ssh && chmod 700 /root/.ssh
+
+RUN echo $SSH_PUBLIC_KEY >> "/root/.ssh/authorized_keys"
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/security/remote_devices/ssh-tunneling/README.md
+++ b/security/remote_devices/ssh-tunneling/README.md
@@ -1,0 +1,7 @@
+# Reference Implementaton for SSH Tunneling on EdgeX Device Services
+
+This is a reference implementation for using SSH Tunneling on EdgeX device-virtual services.
+
+## Build and Run
+
+Please see the detailed steps in "how-to guide" for SSH Tunneling in documentation repository here: <https://github.com/edgexfoundry/edgex-docs/blob/master/docs_src/microservices/security/Ch-SSH-Tunneling-HowToSecureDeviceServices.md#put-it-all-together>.

--- a/security/remote_devices/ssh-tunneling/Vagrantfile
+++ b/security/remote_devices/ssh-tunneling/Vagrantfile
@@ -1,0 +1,94 @@
+#  ----------------------------------------------------------------------------------
+#  Copyright 2020 Intel Corp.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/bionic64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  config.vm.network "forwarded_port", guest: 2223, host: 2223
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+    vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    # Install last version of Docker
+    curl -fsSL https://test.docker.com -o test-docker.sh
+    sh test-docker.sh # helper script installs the beta package    # Add default user in docker group
+    usermod -aG docker vagrant
+    # Install docker-compose package
+    curl -L https://github.com/docker/compose/releases/download/1.25.5/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+    docker-compose --version
+  SHELL
+end

--- a/security/remote_devices/ssh-tunneling/build.sh
+++ b/security/remote_devices/ssh-tunneling/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#  ----------------------------------------------------------------------------------
+#  Copyright 2020 Intel Corp.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+DEFAULT_SSH_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKvsFf5HocBOBWXdVJKfQzkhf0K8lSLjZn9PX84VdhHyP8n1mzfpZywA4vsz8+A3OsGHAr2xpkyzOS0YkwD7nrI3q1x0A0+ANhQNOaKbnfQRepTAES3FPm5n0AbNVfgOre3RR2NLOt6M5m3mA/MERNer1fEp6BM96sdU0o3KjqwFGkPufoQrVkpz2691MZ6/ACDc+lk7uQrinsB4YxM7ctiLNl4I1A3TJgVv0jkJImUCHaThYj3XoaqUqUjQFTS7SlFfkXuk13EjNfRzqPwKFnVvGTUaYzaBV5S4wt5XCxhLfs497M2k5zmNx3HFY/GEyeoroCpjsiXkm+HcgdIYb7 root"
+
+# override the new SSH public key from the environment variable if any; otherwise use default
+SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY-"$DEFAULT_SSH_KEY"}
+export SSH_PUBLIC_KEY
+
+echo "SSH_PUBLIC_KEY to be injected:" $SSH_PUBLIC_KEY
+
+docker build --build-arg SSH_PUBLIC_KEY="$SSH_PUBLIC_KEY" -t eg_sshd .

--- a/security/remote_devices/ssh-tunneling/ds-proxy-entrypoint.sh
+++ b/security/remote_devices/ssh-tunneling/ds-proxy-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2020 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+# Use dumb-init as PID 1 in order to reap zombie processes and forward system signals to 
+# all processes in its session. This can alleviate the chance of leaking zombies, 
+# thus more graceful termination of all sub-processes if any.
+
+# ssh key generated and put under /root/.ssh/ in the container
+rm -rf /root/.ssh && mkdir /root/.ssh \
+&& cp -R /root/ssh/* /root/.ssh/ \
+&& chmod -R 700 /root/.ssh/* \
+&& chmod -R 600 /root/.ssh/id_rsa.* \
+&& ls -al /root/.ssh/* \
+&& cat /root/.ssh/id_rsa.pub
+
+# ssh tunneling for both ways
+sshTunneling="ssh -vv -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  -N $TUNNEL_HOST \
+  -L *:$SERVICE_PORT:$SERVICE_HOST:$SERVICE_PORT \
+  -R 0.0.0.0:48080:edgex-core-data:48080 \
+  -R 0.0.0.0:5563:edgex-core-data:5563 \
+  -R 0.0.0.0:48081:edgex-core-metadata:48081 \
+  -R 0.0.0.0:8500:edgex-core-consul:8500 \
+  -p $TUNNEL_SSH_PORT && while true; do sleep 60; done"
+
+echo "Executing $@"
+"$@"
+
+#sleep for some time to wait for creating authorized_keys on remote side
+sleep 3
+
+echo "Executing hook=$sshTunneling"
+eval $sshTunneling

--- a/security/remote_devices/ssh-tunneling/edgex-core-ssh-proxy.yml
+++ b/security/remote_devices/ssh-tunneling/edgex-core-ssh-proxy.yml
@@ -1,0 +1,590 @@
+# /*******************************************************************************
+#  * Copyright 2020 Redis Labs
+#  * Copyright 2020 Intel Corporation.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  * @author: Andre Srinivasan, Redis Labs
+#  * @author: Leonard Goodell, Intel
+#  * EdgeX Foundry, Geneva, version 1.2.0
+#  * added: May 14, 2020
+#  *******************************************************************************/
+
+version: '3.4'
+
+# all common shared environment variables defined here:
+x-common-env-variables: &common-variables
+  Registry_Host: edgex-core-consul
+  Clients_CoreData_Host: edgex-core-data
+  Clients_Notifications_Host: edgex-support-notifications
+  Clients_Metadata_Host: edgex-core-metadata
+  Clients_Command_Host: edgex-core-command
+  Clients_Scheduler_Host: edgex-support-scheduler
+  Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
+  Databases_Primary_Type: redisdb
+  Databases_Primary_Host: edgex-redis
+  Databases_Primary_Port: 6379
+  SecretStore_Host: edgex-vault
+  SecretStore_ServerName: edgex-vault
+  SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
+  # Required in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
+
+# REDIS5_PASSWORD_PATHNAME must have the same value as
+# security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue
+# #2503 that will address this.
+x-redis5-env-variables: &redis5-variables
+  REDIS5_PASSWORD_PATHNAME: /tmp/edgex/secrets/edgex-redis/redis5-password
+
+volumes:
+  db-data:
+  log-data:
+  consul-config:
+  consul-data:
+  consul-scripts:
+  vault-init:
+  vault-config:
+  vault-file:
+  vault-logs:
+  # non-shared volumes
+  secrets-setup-cache:
+
+services:
+  consul:
+    image: edgexfoundry/docker-edgex-consul:1.2.0
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+    container_name: edgex-core-consul
+    hostname: edgex-core-consul
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-consul
+    volumes:
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - consul-scripts:/consul/scripts:z
+      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-consul:/tmp/edgex/secrets/edgex-consul:ro,z
+      - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
+      - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+    environment:
+      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+      - EDGEX_DB=redis
+      - EDGEX_SECURE=true
+    depends_on:
+      - security-secrets-setup
+
+  vault:
+    image: vault:1.3.1
+    container_name: edgex-vault
+    hostname: edgex-vault
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-vault
+    ports:
+      - "127.0.0.1:8200:8200"
+    cap_add:
+      - "IPC_LOCK"
+    tmpfs:
+      - /vault/config
+    entrypoint: ["/vault/init/start_vault.sh"]
+    environment:
+      - VAULT_ADDR=https://edgex-vault:8200
+      - VAULT_CONFIG_DIR=/vault/config
+      - VAULT_UI=true
+    volumes:
+      - vault-file:/vault/file:z
+      - vault-logs:/vault/logs:z
+      - vault-init:/vault/init:ro,z
+      - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
+    depends_on:
+      - consul
+      - security-secrets-setup
+
+  security-secrets-setup:
+    image: edgexfoundry/docker-edgex-secrets-setup-go:1.2.0
+    container_name: edgex-secrets-setup
+    hostname: edgex-secrets-setup
+    environment:
+      <<: *redis5-variables
+    tmpfs:
+      - /tmp
+      - /run
+    command: "generate"
+    volumes:
+      - secrets-setup-cache:/etc/edgex/pki
+      - vault-init:/vault/init:z
+      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
+
+  vault-worker:
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.2.0
+    container_name: edgex-vault-worker
+    hostname: edgex-vault-worker
+    environment:
+      <<: *redis5-variables
+      SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-vault-worker
+    tmpfs:
+      - /run
+    volumes:
+      - vault-config:/vault/config:z
+      - consul-scripts:/consul/scripts:ro,z
+      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
+    depends_on:
+      - security-secrets-setup
+      - consul
+      - vault
+
+# containers for reverse proxy
+  kong-db:
+    image: postgres:12.1-alpine
+    container_name: kong-db
+    hostname: kong-db
+    networks:
+      edgex-network:
+        aliases:
+            - kong-db
+    ports:
+        - "127.0.0.1:5432:5432"
+    environment:
+        - 'POSTGRES_DB=kong'
+        - 'POSTGRES_USER=kong'
+        - 'POSTGRES_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
+    depends_on:
+      - security-secrets-setup
+
+  kong-migrations:
+    image: kong:${KONG_VERSION:-2.0.1}
+    container_name: kong-migrations
+    networks:
+      edgex-network:
+        aliases:
+            - kong-migrations
+    environment:
+        - 'KONG_DATABASE=postgres'
+        - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
+    command: >
+      /bin/sh -cx 
+      'until /consul/scripts/consul-svc-healthy.sh kong-db;
+         do sleep 1;
+      done && kong migrations bootstrap;
+      kong migrations list;
+      code=$$?;
+      if [ $$code -eq 5 ]; then
+        kong migrations up && kong migrations finish;
+      fi'
+    volumes:
+      - consul-scripts:/consul/scripts:ro,z
+    depends_on:
+      - consul
+      - kong-db
+
+  kong:
+    image: kong:${KONG_VERSION:-2.0.1}
+    container_name: kong
+    hostname: kong
+    networks:
+      edgex-network:
+        aliases:
+            - kong
+    ports:
+        - "8000:8000"
+        - "127.0.0.1:8001:8001"
+        - "8443:8443"
+        - "127.0.0.1:8444:8444"
+    tty: true
+    environment:
+        - 'KONG_DATABASE=postgres'
+        - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PG_PASSWORD=${KONG_POSTGRES_PASSWORD:-kong}'
+        - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
+        - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
+        - 'KONG_PROXY_ERROR_LOG=/dev/stderr'
+        - 'KONG_ADMIN_ERROR_LOG=/dev/stderr'
+        - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
+    restart: on-failure
+    command: >
+      /bin/sh -c 
+      "until /consul/scripts/consul-svc-healthy.sh kong-migrations; do sleep 1; done;
+      /docker-entrypoint.sh kong docker-start"
+    volumes:
+      - consul-scripts:/consul/scripts:ro,z
+    depends_on:
+      - consul
+      - kong-db
+      - kong-migrations
+
+  edgex-proxy:
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.2.0
+    container_name: edgex-proxy
+    hostname: edgex-proxy
+    entrypoint: >
+      /bin/sh -c 
+      "until /consul/scripts/consul-svc-healthy.sh kong; do sleep 1; done;
+      until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
+      /edgex/security-proxy-setup --init=true"
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-proxy
+    environment:
+      <<: *common-variables
+      KongURL_Server: kong
+      SecretService_Server: edgex-vault
+      SecretService_TokenPath: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
+      SecretService_CACertPath: /tmp/edgex/secrets/ca/ca.pem
+      SecretService_SNIS: "edgex-kong"
+    volumes:
+      - consul-scripts:/consul/scripts:ro,z
+      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-security-proxy-setup:/tmp/edgex/secrets/edgex-security-proxy-setup:ro,z
+    depends_on:
+      - consul
+      - vault-worker
+      - kong
+
+# end of containers for reverse proxy
+
+  redis:
+    image: redis:5.0.8-alpine
+    ports:
+      - "127.0.0.1:6379:6379"
+    container_name: edgex-redis
+    hostname: edgex-redis
+    environment:
+      <<: *redis5-variables
+    command: |
+      /bin/sh -c "
+      until [ -r $${REDIS5_PASSWORD_PATHNAME} ] && [ -s $${REDIS5_PASSWORD_PATHNAME} ]; do sleep 1; done
+      exec /usr/local/bin/docker-entrypoint.sh --requirepass `cat $${REDIS5_PASSWORD_PATHNAME}` \
+        --dir /data \
+        --save 900 1 \
+        --save 300 10 \
+        --save 60 10000
+      "
+    networks:
+      - edgex-network
+    volumes:
+      - db-data:/data:z
+      - /tmp/edgex/secrets/edgex-redis:/tmp/edgex/secrets/edgex-redis:z
+    depends_on:
+      - vault-worker
+
+# The logging service has been deprecated in Geneva release and will be removed in the Hanoi release.
+# All services are configure to send logging to STDOUT, i.e. not remote which requires this logging service
+# If you still must use remote logging, un-comment the block below, all the related depends that have been commented out
+# and the related global override that are commented out at the top.
+#
+#  logging:
+#    image: edgexfoundry/docker-support-logging-go:1.2.0
+#    ports:
+#      - "127.0.0.1:48061:48061"
+#    container_name: edgex-support-logging
+#    hostname: edgex-support-logging
+#    networks:
+#      - edgex-network
+#    environment:
+#      <<: *common-variables
+#      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-logging/secrets-token.json
+#      Service_Host: edgex-support-logging
+#      Writable_Persistence: file
+#      Databases_Primary_Type: file
+#      Logging_EnableRemote: "false"
+#    volumes:
+#      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+#      - /tmp/edgex/secrets/edgex-support-logging:/tmp/edgex/secrets/edgex-support-logging:ro,z
+#    depends_on:
+#      - consul
+#      - vault-worker
+
+  system:
+    image: edgexfoundry/docker-sys-mgmt-agent-go:1.2.0
+    ports:
+      - "127.0.0.1:48090:48090"
+    container_name: edgex-sys-mgmt-agent
+    hostname: edgex-sys-mgmt-agent
+    networks:
+      - edgex-network
+    environment:
+      <<: *common-variables
+      Service_Host: edgex-sys-mgmt-agent
+      ExecutorPath: /sys-mgmt-executor
+      MetricsMechanism: executor
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:z
+    depends_on:
+      - consul
+#      - logging  # uncomment if re-enabled remote logging
+      - scheduler
+      - notifications
+      - metadata
+      - data
+      - command
+
+  notifications:
+    image: edgexfoundry/docker-support-notifications-go:1.2.0
+    ports:
+      - "127.0.0.1:48060:48060"
+    container_name: edgex-support-notifications
+    hostname: edgex-support-notifications
+    networks:
+      - edgex-network
+    environment:
+      <<: *common-variables
+      Service_Host: edgex-support-notifications
+      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-notifications/secrets-token.json
+    volumes:
+      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-support-notifications:/tmp/edgex/secrets/edgex-support-notifications:ro,z
+    depends_on:
+      - consul
+#      - logging  # uncomment if re-enabled remote logging
+      - redis
+      - vault-worker
+
+  metadata:
+    image: edgexfoundry/docker-core-metadata-go:1.2.0
+    ports:
+      - "48081:48081"
+    container_name: edgex-core-metadata
+    hostname: edgex-core-metadata
+    networks:
+      - edgex-network
+    environment:
+      <<: *common-variables
+      Service_Host: edgex-core-metadata
+      Notifications_Sender: edgex-core-metadata
+      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-core-metadata/secrets-token.json
+    volumes:
+      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-core-metadata:/tmp/edgex/secrets/edgex-core-metadata:ro,z
+    depends_on:
+      - consul
+#      - logging  # uncomment if re-enabled remote logging
+      - redis
+      - notifications
+      - vault-worker
+
+  data:
+    image: edgexfoundry/docker-core-data-go:1.2.0
+    ports:
+      - "48080:48080"
+      - "5563:5563"
+    container_name: edgex-core-data
+    hostname: edgex-core-data
+    networks:
+      - edgex-network
+    environment:
+      <<: *common-variables
+      Service_Host: edgex-core-data
+      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-core-data/secrets-token.json
+    volumes:
+      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-core-data:/tmp/edgex/secrets/edgex-core-data:ro,z
+    depends_on:
+      - consul
+#      - logging  # uncomment if re-enabled remote logging
+      - redis
+      - metadata
+      - vault-worker
+
+  command:
+    image: edgexfoundry/docker-core-command-go:1.2.0
+    ports:
+      - "48082:48082"
+    container_name: edgex-core-command
+    hostname: edgex-core-command
+    networks:
+      - edgex-network
+    environment:
+      <<: *common-variables
+      Service_Host: edgex-core-command
+      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-core-command/secrets-token.json
+    volumes:
+      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-core-command:/tmp/edgex/secrets/edgex-core-command:ro,z
+    depends_on:
+      - consul
+#      - logging  # uncomment if re-enabled remote logging
+      - redis
+      - metadata
+      - vault-worker
+
+  scheduler:
+    image: edgexfoundry/docker-support-scheduler-go:1.2.0
+    ports:
+      - "48085:48085"
+    container_name: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    networks:
+      - edgex-network
+    environment:
+      <<: *common-variables
+      Service_Host: edgex-support-scheduler
+      IntervalActions_ScrubPushed_Host: edgex-core-data
+      IntervalActions_ScrubAged_Host: edgex-core-data
+      SecretStore_TokenFile: /tmp/edgex/secrets/edgex-support-scheduler/secrets-token.json
+    volumes:
+      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
+      - /tmp/edgex/secrets/edgex-support-scheduler:/tmp/edgex/secrets/edgex-support-scheduler:ro,z
+    depends_on:
+      - consul
+#      - logging  # uncomment if re-enabled remote logging
+      - redis
+      - vault-worker
+
+#################################################################
+# Device Services
+#################################################################
+
+# NOTE: all device micro services are commented out on the primary machine 
+# or host to demonstrate that the SSH tunneling is actually utilizing the 
+# secondary or remote running device services
+
+#   device-virtual:
+#     image: edgexfoundry/docker-device-virtual-go:1.2.0
+#     ports:
+#     - "127.0.0.1:49990:49990"
+#     container_name: edgex-device-virtual
+#     hostname: edgex-device-virtual
+#     networks:
+#       edgex-network:
+#         aliases:
+#         - edgex-device-virtual
+#     environment:
+#       <<: *common-variables
+#       Service_Host: edgex-device-virtual
+#     depends_on:
+#       - consul
+# #      - logging  # uncomment if re-enabled remote logging
+#       - data
+#       - metadata
+
+  # device-rest:
+  #   image: edgexfoundry/docker-device-rest-go:1.1.0
+  #   ports:
+  #     - "127.0.0.1:49986:49986"
+  #   container_name: edgex-device-rest
+  #   hostname: edgex-device-rest
+  #   networks:
+  #     edgex-network:
+  #       aliases:
+  #         - edgex-device-rest
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-rest
+  #   depends_on:
+  #     - data
+  #     - command
+  #      - logging  # uncomment if re-enabled remote logging
+
+  # device-random:
+  #   image: edgexfoundry/docker-device-random-go:1.2.0
+  #   ports:
+  #     - "127.0.0.1:49988:49988"
+  #   container_name: edgex-device-random
+  #   hostname: edgex-device-random
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-random
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-random
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-mqtt:
+  #   image: edgexfoundry/docker-device-mqtt-go:1.2.0
+  #   ports:
+  #     - "127.0.0.1:49982:49982"
+  #   container_name: edgex-device-mqtt
+  #   hostname: edgex-device-mqtt
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-mqtt
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-mqtt
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-modbus:
+  #   image: edgexfoundry/docker-device-modbus-go:1.2.0
+  #   ports:
+  #     - "127.0.0.1:49991:49991"
+  #   container_name: edgex-device-modbus
+  #   hostname: edgex-device-modbus
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-modbus
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-modbus
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-snmp:
+  #   image: edgexfoundry/docker-device-snmp-go:1.2.0
+  #   ports:
+  #     - "127.0.0.1:49993:49993"
+  #   container_name: edgex-device-snmp
+  #   hostname: edgex-device-snmp
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-snmp
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-snmp
+  #   depends_on:
+  #     - data
+  #     - command
+
+##########################################################
+# ssh tunneling proxy service for device-virtual
+##########################################################
+  device-ssh-proxy:
+    image: device-ssh-proxy:test
+    container_name: edgex-device-ssh-proxy
+    hostname: edgex-device-ssh-proxy
+    volumes:
+      - $HOME/.ssh:/root/ssh:ro
+    ports:
+      - "49990:49990"
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-device-virtual
+    environment:
+      TUNNEL_HOST: 192.168.1.190
+      TUNNEL_SSH_PORT: 2223
+      SERVICE_HOST: edgex-device-virtual
+      SERVICE_PORT: 49990
+
+networks:
+  edgex-network:
+    driver: "bridge"

--- a/security/remote_devices/ssh-tunneling/edgex-device-sshd-remote.yml
+++ b/security/remote_devices/ssh-tunneling/edgex-device-sshd-remote.yml
@@ -1,0 +1,182 @@
+# /*******************************************************************************
+#  * Copyright 2020 Redis Labs
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  * Andre Srinivasan
+#  * added: April, 2020
+#  *******************************************************************************/
+
+version: '3.4'
+
+# all common shared environment variables defined here:
+x-common-env-variables: &common-variables
+  Registry_Host: edgex-core-consul
+  Clients_CoreData_Host: edgex-core-data
+  Clients_Notifications_Host: edgex-support-notifications
+  Clients_Metadata_Host: edgex-core-metadata
+  Clients_Command_Host: edgex-core-command
+  Clients_Scheduler_Host: edgex-support-scheduler
+  Clients_RulesEngine_Host: edgex-kuiper
+  Clients_VirtualDevice_Host: edgex-device-virtual
+  Databases_Primary_Type: redisdb
+  Databases_Primary_Host: edgex-redis
+  Databases_Primary_Port: 6379
+  SecretStore_Host: edgex-vault
+  SecretStore_ServerName: edgex-vault
+  SecretStore_RootCaCertPath: /tmp/edgex/secrets/ca/ca.pem
+  # Require in case old configuration from previous release used.
+  # Change to "true" if re-enabling logging service for remote logging
+  Logging_EnableRemote: "false"
+  #  Clients_Logging_Host: edgex-support-logging # un-comment if re-enabling logging service for remote logging
+
+# REDIS5_PASSWORD_PATHNAME must have the same value as
+# security-secretstore-read/res/configuration.toml SecretStore.Passwordfile. Note edgex-go issue
+# #2503 that will address this.
+x-redis5-env-variables: &redis5-variables
+  REDIS5_PASSWORD_PATHNAME: /tmp/edgex/secrets/edgex-redis/redis5-password
+
+volumes:
+  db-data:
+  log-data:
+  consul-config:
+  consul-data:
+  consul-scripts:
+  vault-init:
+  vault-config:
+  vault-file:
+  vault-logs:
+  # non-shared volumes
+  secrets-setup-cache:
+
+services:
+# only device services on the remote machine
+# the other dependencies of EdgeX core-servcies are served from 
+# the Reverse tunneling of the primary machine
+
+#################################################################
+# Device Services
+#################################################################
+
+  device-virtual:
+    image: edgexfoundry/docker-device-virtual-go:1.2.0
+    container_name: edgex-device-virtual
+    hostname: edgex-device-virtual
+    networks:
+      edgex-network:
+        aliases:
+        - edgex-device-virtual
+    environment:
+      <<: *common-variables
+      Service_Host: edgex-device-virtual
+
+  # device-rest:
+  #   image: edgexfoundry/docker-device-rest-go:1.1.0
+  #   ports:
+  #     - "49986:49986"
+  #   container_name: edgex-device-rest
+  #   hostname: edgex-device-rest
+  #   networks:
+  #     edgex-network:
+  #       aliases:
+  #         - edgex-device-rest
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-rest
+
+  # device-random:
+  #   image: nexus3.edgexfoundry.org:10004/docker-device-random-go:master
+  #   ports:
+  #     - "127.0.0.1:49988:49988"
+  #   container_name: edgex-device-random
+  #   hostname: edgex-device-random
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-random
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-random
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-mqtt:
+  #   image: nexus3.edgexfoundry.org:10004/docker-device-mqtt-go:master
+  #   ports:
+  #     - "127.0.0.1:49982:49982"
+  #   container_name: edgex-device-mqtt
+  #   hostname: edgex-device-mqtt
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-mqtt
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-mqtt
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-modbus:
+  #   image: nexus3.edgexfoundry.org:10004/docker-device-modbus-go:master
+  #   ports:
+  #     - "127.0.0.1:49991:49991"
+  #   container_name: edgex-device-modbus
+  #   hostname: edgex-device-modbus
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-modbus
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-modbus
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-snmp:
+  #   image: nexus3.edgexfoundry.org:10004/docker-device-snmp-go:master
+  #   ports:
+  #     - "127.0.0.1:49993:49993"
+  #   container_name: edgex-device-snmp
+  #   hostname: edgex-device-snmp
+  #   networks:
+  #     - edgex-network
+  #      aliases:
+  #      - edgex-device-snmp
+  #   environment:
+  #     <<: *common-variables
+  #     Service_Host: edgex-device-snmp
+  #   depends_on:
+  #     - data
+  #     - command
+
+################################################################
+# SSH Daemon
+################################################################
+  sshd-remote:
+    image: eg_sshd
+    ports:
+      - "2223:22"
+    container_name: edgex-sshd-remote
+    hostname: edgex-sshd-remote
+    networks:
+      edgex-network:
+        aliases:
+        - edgex-core-consul
+        - edgex-core-data
+        - edgex-core-metadata
+
+
+networks:
+  edgex-network:
+    driver: "bridge"


### PR DESCRIPTION

Move all the artifacts for SSH Tunneling examples of remote device service from
 edgexfoundry-holding/external-device-security-examples/pull/1 into this PR

 Closes: #5

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #5 


## What is the new behavior?
Add artifacts of reference example of ssh tunneling for device service.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
Relate to: edgexfoundry/edgex-docs/issues/134
