### PR TITLE
feat: add fledge export example

### DIFF
--- a/application-services/custom/fledge-export/.gitignore
+++ b/application-services/custom/fledge-export/.gitignore
@@ -1,0 +1,6 @@
+.vscode
+go.sum
+coverage.out
+logs/
+.idea
+VERSION

--- a/application-services/custom/fledge-export/.gitignore
+++ b/application-services/custom/fledge-export/.gitignore
@@ -4,3 +4,4 @@ coverage.out
 logs/
 .idea
 VERSION
+*.exe

--- a/application-services/custom/fledge-export/Makefile
+++ b/application-services/custom/fledge-export/Makefile
@@ -1,0 +1,42 @@
+.PHONY: build test clean docker
+
+GO=CGO_ENABLED=1 go
+
+# VERSION file is not needed for local development, In the CI/CD pipeline, a temporary VERSION file is written
+# if you need a specific version, just override below
+APPVERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
+
+# This pulls the version of the SDK from the go.mod file. If the SDK is the only required module,
+# it must first remove the word 'required' so the offset of $2 is the same if there are multiple required modules
+SDKVERSION=$(shell cat ./go.mod | grep 'github.com/edgexfoundry/app-functions-sdk-go v' | sed 's/require//g' | awk '{print $$2}')
+
+MICROSERVICE=fledge-export
+GOFLAGS=-ldflags "-X github.com/edgexfoundry/app-functions-sdk-go/internal.SDKVersion=$(SDKVERSION) -X github.com/edgexfoundry/app-functions-sdk-go/internal.ApplicationVersion=$(APPVERSION)"
+
+GIT_SHA=$(shell git rev-parse HEAD)
+
+build:
+	$(GO) build $(GOFLAGS) -o $(MICROSERVICE)
+
+# NOTE: This is only used for local development. Jenkins CI does not use this make target
+docker:
+	docker build \
+	    --build-arg http_proxy \
+	    --build-arg https_proxy \
+		-f Dockerfile \
+		--label "git_sha=$(GIT_SHA)" \
+		-t edgexfoundry/docker-fledge-export:$(GIT_SHA) \
+		-t edgexfoundry/docker-fledge-export:master-dev \
+		-t nexus3.edgexfoundry.org:10004/docker-fledge-export:master-dev \
+		.
+
+test:
+	$(GO) test -coverprofile=coverage.out ./...
+	$(GO) vet ./...
+	gofmt -l .
+	[ "`gofmt -l .`" = "" ]
+	./bin/test-go-mod-tidy.sh
+	./bin/test-attribution-txt.sh
+
+clean:
+	rm -f $(MICROSERVICE)

--- a/application-services/custom/fledge-export/README.md
+++ b/application-services/custom/fledge-export/README.md
@@ -1,0 +1,52 @@
+# Fledge Export
+
+This example shows how to get data (readings) from an EdgeX Foundry instance to [LF Edge](https://www.lfedge.org/) sister project [Fledge](https://www.lfedge.org/projects/fledge/).
+
+Fledge offers North and South plugins.  In this example, EdgeX Foundry is sending sensor/device data via a custom [application service](https://docs.edgexfoundry.org/1.2/microservices/application/ApplicationServices/) to the [Fledge South HTTP plugin](https://fledge-iot.readthedocs.io/en/v1.8.1/plugins/fledge-south-http/index.html#).
+
+## Fledge Version
+
+This example was created with Fledge version 1.8.  
+
+## Fledge Setup and Configuration
+
+See the [Fledge documentation](https://fledge-iot.readthedocs.io/en/v1.8.1/quick_start.html) on how to setup and configure Fledge.
+
+See the [Fledge Plugin documentation](https://fledge-iot.readthedocs.io/en/v1.8.1/plugins/fledge-south-http/index.html) for information on how to install and configure the South HTTP plugin.
+
+## Build and Run
+
+A Makefile has been provide to easily create and execute this service.  In order to build the micro service executable run the `make build` from the root directory of this example.
+
+Once the micro service has successfully been compiled, run the executable created in the root directory with `./fledge-export`.
+
+## Configuration
+
+In order to supply data from your EdgeX instance to your Fledge instance, you must provide the REST endpoint for the Fledge South HTTP plugin.  Open the `configuration.toml` file in the `res` folder and change the address associated `FledgeSouthHTTPEndpoint` in the `ApplicationSettings` configuration section.
+
+``` toml
+    [ApplicationSettings]
+    FledgeSouthHTTPEndpoint = "http://192.168.0.10:6683/sensor-reading"
+```
+
+Unless you made changes to the default configuration when installing the Fledge South HTTP plugin, you should only need to change the IP address of your Fledge instance. 
+
+## Data Payload
+
+EdgeX uses the Fledge payload format to export EdgeX Readings (per each EdgeX Event) to Fledge.  The South HTTP Plugin requires the data to be sent in the following way:
+
+``` JSON
+    [
+        {
+            "timestamp" : "2020-07-08 16:16:07.263657+00:00",
+            "asset" : "motor1",
+            "readings" : {
+                "voltage" : 239.4,
+                "current" : 1003,
+                "rpm" : 120147
+            }
+        }
+    ]
+```
+
+The `asset` is set with the EdgeX device name.  The `readings` hold the EdgeX Reading name and value pairs.  The `timestamp` is set from the Event's created timestamp.

--- a/application-services/custom/fledge-export/go.mod
+++ b/application-services/custom/fledge-export/go.mod
@@ -1,0 +1,8 @@
+module fledge-export
+
+go 1.15
+
+require (
+	github.com/edgexfoundry/app-functions-sdk-go v1.2.1-dev.55
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.111
+)

--- a/application-services/custom/fledge-export/main.go
+++ b/application-services/custom/fledge-export/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/appsdk"
+	"github.com/edgexfoundry/app-functions-sdk-go/pkg/transforms"
+
+	fledgeTransforms "fledge-export/pkg/transforms"
+)
+
+func main() {
+
+	// 1) First thing to do is to create an instance of the EdgeX SDK, giving it a service key
+	edgexSdk := &appsdk.AppFunctionsSDK{
+		ServiceKey: "FledgeExport", // Key used by Registry (Aka Consul)
+	}
+
+	// 2) Next, we need to initialize the SDK
+	if err := edgexSdk.Initialize(); err != nil {
+		message := fmt.Sprintf("SDK initialization failed: %v\n", err)
+		if edgexSdk.LoggingClient != nil {
+			edgexSdk.LoggingClient.Error(message)
+		} else {
+			fmt.Println(message)
+		}
+		os.Exit(-1)
+	}
+
+	// 3) Shows how to access the application's specific configuration settings.
+	fledgeEndpoint, err := edgexSdk.GetAppSettingStrings("FledgeSouthHTTPEndpoint")
+	if err != nil {
+		edgexSdk.LoggingClient.Error(err.Error())
+		os.Exit(-1)
+	}
+
+	// 4) This is our pipeline configuration, the collection of functions to
+	// execute every time an event is triggered.
+	if err := edgexSdk.SetFunctionsPipeline(
+		//transforms.NewConversion().TransformToJSON,
+		fledgeTransforms.NewConversion().TransformToFledge,
+		transforms.NewHTTPSender(fledgeEndpoint[0], "application/json", false).HTTPPost,
+	); err != nil {
+		edgexSdk.LoggingClient.Error(fmt.Sprintf("SDK SetPipeline failed: %v\n", err))
+		os.Exit(-1)
+	}
+
+	// 5) Lastly, we'll go ahead and tell the SDK to "start" and begin listening for events to trigger the pipeline.
+	err = edgexSdk.MakeItRun()
+	if err != nil {
+		edgexSdk.LoggingClient.Error("MakeItRun returned error: ", err.Error())
+		os.Exit(-1)
+	}
+
+	// Do any required cleanup here
+
+	os.Exit(0)
+}

--- a/application-services/custom/fledge-export/pkg/transforms/conversion.go
+++ b/application-services/custom/fledge-export/pkg/transforms/conversion.go
@@ -1,0 +1,61 @@
+package transforms
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/edgexfoundry/app-functions-sdk-go/appcontext"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type Conversion struct {
+}
+
+func NewConversion() Conversion {
+	return Conversion{}
+}
+
+type FledgeReading struct {
+	Timestamp string                 `json:"timestamp"`
+	Asset     string                 `json:"asset"`
+	Readings  map[string]interface{} `json:"readings,omitempty"`
+}
+
+func newFledgeReading(stamp int64, asset string) *FledgeReading {
+	tm := time.Unix(0, stamp*int64(time.Millisecond))
+	reading := FledgeReading{Timestamp: tm.String(), Asset: asset}
+	reading.Readings = make(map[string]interface{})
+	return &reading
+}
+
+// TransformToFledge ...
+func (f Conversion) TransformToFledge(edgexcontext *appcontext.Context, params ...interface{}) (continuePipeline bool, stringType interface{}) {
+	if len(params) < 1 {
+		return false, errors.New("No Event Received")
+	}
+
+	edgexcontext.LoggingClient.Debug("Transforming to Fledge format")
+
+	if event, ok := params[0].(models.Event); ok {
+		payload := make([]FledgeReading, 1)
+		fReading := newFledgeReading(event.Created, event.Device)
+		payload[0] = *fReading
+
+		for _, reading := range event.Readings {
+			fReading.Readings[reading.Name] = reading.Value
+		}
+
+		msg, err := json.Marshal(payload)
+		if err != nil {
+			return false, errors.New(fmt.Sprintf("Failed to transform Fledge data: %s", err))
+		}
+
+		edgexcontext.LoggingClient.Debug(fmt.Sprintf("Fledge Payload: %s", msg))
+
+		return true, string(msg)
+	}
+
+	return false, errors.New("Unexpected type received")
+}

--- a/application-services/custom/fledge-export/res/configuration.toml
+++ b/application-services/custom/fledge-export/res/configuration.toml
@@ -1,0 +1,52 @@
+[Writable]
+LogLevel = 'INFO'
+
+[Service]
+BootTimeout = "30s"
+CheckInterval = "10s"
+Host = "localhost"
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
+Port = 50001
+Protocol = "http"
+ReadMaxLimit = 100
+StartupMsg = 'LF Edge Fledge Export Service'
+Timeout = "5s"
+
+[Registry]
+Host = "localhost"
+Port = 8500
+Type = "consul"
+
+[Clients]
+  [Clients.CoreData]
+  Protocol = "http"
+  Host = "localhost"
+  Port = 48080
+
+  [Clients.Logging]
+  Protocol = "http"
+  Host = "localhost"
+  Port = 48061
+
+[Binding]
+Type="messagebus"
+SubscribeTopic="events"
+PublishTopic=""
+
+[MessageBus]
+Type = "zero"
+    [MessageBus.SubscribeHost]
+        Host = "localhost"
+        Port = 5563
+        Protocol = "tcp"
+    [MessageBus.PublishHost]
+        Host = "*"
+        Port = 5566
+        Protocol = "tcp"
+
+[Logging]
+EnableRemote = false
+File = ""
+
+[ApplicationSettings]
+FledgeSouthHTTPEndpoint = "http://192.168.0.10:6683/sensor-reading"


### PR DESCRIPTION
Example  using a custom app service to export data from EdgeX to Fledge through the Fledge South Http Plugin

Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?
Addition of app service export to Fledge via Fledge South Http Plugin - as recommended by the Fledge project.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information