### PR TITLE
docs(deploy): fix broken table syntax

### DIFF
--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -158,6 +158,7 @@ Once EdgeX is running in Kubernetes, you can explore the APIs and services as yo
 However, the port mapping to expose EdgeX services externally (outside of the Kubernetes environment) is different.  Kubernetes service node port range is between 30000-32767, so appropriate ports in this range have been selected to expose the EdgeX services externally.
 
 | EdgeX Service | EdgeX Port | External Port for the service with K8s |
+|---------------|------------|----------------------------------------|
 | Consul | 8500 | 30850 |
 | Consul | 8400 | 30840 |
 | Notifications | 48060 | 30060 |


### PR DESCRIPTION
Signed-off-by: kurokobo <2920259+kurokobo@users.noreply.github.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The table is broken because of missing line separator.

![image](https://user-images.githubusercontent.com/2920259/105171665-dd701e80-5b61-11eb-9a3b-15c7ce856032.png)

## Issue Number:


## What is the new behavior?

The table is displayed as table.

![image](https://user-images.githubusercontent.com/2920259/105171900-27590480-5b62-11eb-932d-8f7193c03c43.png)

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information