### PR TITLE
fix: Adjust JSONLogic rules for change from device to DeviceName

### DIFF
--- a/application-services/custom/json-logic/Makefile
+++ b/application-services/custom/json-logic/Makefile
@@ -3,6 +3,7 @@
 GO=CGO_ENABLED=1 GO111MODULE=on go
 
 build:
+	go mod tidy
 	$(GO) build -o app-service
 
 clean:

--- a/application-services/custom/json-logic/README.md
+++ b/application-services/custom/json-logic/README.md
@@ -10,7 +10,7 @@ This example demonstrates a few different ways to leverage JSON logic to assist 
 This first example starts out simple to demonstrate how JSON logic can be used to accomplish the same thing provided by the FilterByDeviceName transform.
 
 ``` go
-jsonlogicrule := "{ \"in\" : [{ \"var\" : \"device\" }, [\"Random-Integer-Device\",\"Random-Float-Device\"] ] }"
+jsonlogicrule := "{ \"in\" : [{ \"var\" : \"deviceName\" }, [\"Random-Integer-Device\",\"Random-Float-Device\"] ] }"
 
 edgexSdk.SetFunctionsPipeline(		
     transforms.NewJSONLogic(jsonlogicrule).Evaluate,
@@ -27,7 +27,7 @@ But what if we wanted to perform an not operation?
 The following rule demonstrates how to filter OUT the list of devices instead of filtering FOR a specific device. 
 
 ``` go
-jsonlogicrule := "{ \"!\" : {\"in\" : [{ \"var\" : \"device\" }, [\"Random-Integer-Device\"] ] }}"
+jsonlogicrule := "{ \"!\" : {\"in\" : [{ \"var\" : \"deviceN\" }, [\"Random-Integer-Device\"] ] }}"
 
 edgexSdk.SetFunctionsPipeline(		
     transforms.NewJSONLogic(jsonlogicrule).Evaluate,

--- a/application-services/custom/json-logic/main.go
+++ b/application-services/custom/json-logic/main.go
@@ -56,10 +56,10 @@ func main() {
 	listOfDevices := strings.Join(deviceNames, "\",\"")
 
 	// Rule to look for a specific set of devices provided (similar to filterbydevicename)
-	jsonlogicrule := "{ \"in\" : [{ \"var\" : \"device\" }, [\"" + listOfDevices + "\"] ] }"
+	jsonlogicrule := "{ \"in\" : [{ \"var\" : \"deviceName\" }, [\"" + listOfDevices + "\"] ] }"
 
 	// Rule to filter out a single device and allow all others
-	//jsonlogicrule := "{ \"!\" : {\"in\" : [{ \"var\" : \"device\" }, [\"" + listOfDevices + "\"] ] }}"
+	//jsonlogicrule := "{ \"!\" : {\"in\" : [{ \"var\" : \"deviceName\" }, [\"" + listOfDevices + "\"] ] }}"
 
 	// Rule to look for values > 0 in float readings -- MUST CONVERT TO READABLE FLOATS FIRST! Uncomment "ConvertToReadableFloatValues"
 	//jsonlogicrule := "{ \"all\" : [ { \"var\" : \"readings\" } , {  \">\" : [ {\"var\":\"value\"}, 0 ] } ] }"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/Contributing.md.

## What is the current behavior?
JSONLogic rules use old name `device`

## Issue Number: n/a


## What is the new behavior?
JSONLogic rules now use new name `deviceName`


## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information