### PR TITLE
fix(security): point to correct links in examples

### DIFF
--- a/security/remote_devices/docker-swarm/README.md
+++ b/security/remote_devices/docker-swarm/README.md
@@ -4,4 +4,4 @@ This is a proof-of-concept demonstrating how to run EdgeX in Docker Swarm using 
 
 ## Build and Run
 
-Please see the detailed steps in "how-to guide" for Docker Swarm in documentation repository here: <https://github.com/edgexfoundry/edgex-docs/blob/master/docs_src/microservices/security/Ch-Docker-Swarm-SecuringDeviceServices.md>.
+Please see the detailed steps in "how-to guide" for Docker Swarm in documentation repository here: <https://github.com/edgexfoundry/edgex-docs/blob/main/docs_src/security/Ch-Docker-Swarm-SecuringDeviceServices.md>.

--- a/security/remote_devices/ssh-tunneling/README.md
+++ b/security/remote_devices/ssh-tunneling/README.md
@@ -4,4 +4,4 @@ This is a reference implementation for using SSH Tunneling on EdgeX device-virtu
 
 ## Build and Run
 
-Please see the detailed steps in "how-to guide" for SSH Tunneling in documentation repository here: <https://github.com/edgexfoundry/edgex-docs/blob/master/docs_src/microservices/security/Ch-SSH-Tunneling-HowToSecureDeviceServices.md#put-it-all-together>.
+Please see the detailed steps in "how-to guide" for SSH Tunneling in documentation repository here: <https://github.com/edgexfoundry/edgex-docs/blob/main/docs_src/security/Ch-SSH-Tunneling-HowToSecureDeviceServices.md#put-it-all-together>.


### PR DESCRIPTION
Links mentioned in the respective `README.md` of the
Docker-Swarm and SSH-Tunneling examples point to
non-existent resources. The links should point to:
1. `main` branch of the edgex-docs repository
2. documents exist under `security` directory and
   not `microservices/security` directory

Closes #101.

Signed-off-by: Shantanoo 'Shan' Desai <shantanoo.desai@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-examples/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)

## Testing Instructions
<!-- How can the reviewers test your change? -->
Accessing the links from their respective `README.md` and reaching the respective documentation in `edgex-docs` successfully