### PR TITLE
fix: device-usb-camera to use the correct start up docker-entrypoint shell script

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -164,6 +164,8 @@ and has been compatibility tested with Rook-Ceph, OpenEBS, and the Rancher Local
 
 The default value of `edgex.security.enabled` is `false`.  This may change in the future.
 
+To enable the security, add the command flag in the helm install: `--set edgex.security.enabled=true`
+
 Setting `edgex.security.enabled` to `true` during installation (recommended)
 will enable microservice-level authentication
 for EdgeX peer-to-peer communcation
@@ -172,6 +174,9 @@ as well authentication to Redis, Consul, and the MQTT broker, if used.
 In lieu of a standalone API gateway used by the snap- and docker-based EdgeX deployments,
 the security-enabled helm chart is coded against a standard Kubernetes NGINX-based ingress controller,
 and ingress routes are configured to require client-side TLS authentication.
+
+The device USB camera by default is not enabled to run in the deployment, to start it in a pod, 
+add the following command flag in the helm install: `--set edgex.replicas.device.usbcamera=1`.
 
 #### Configuring Ingress TLS
 

--- a/deployment/helm/templates/edgex-device-usb-camera/edgex-device-usb-camera-deployment.yaml
+++ b/deployment/helm/templates/edgex-device-usb-camera/edgex-device-usb-camera-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         imagePullPolicy: {{.Values.edgex.image.device.usbcamera.pullPolicy}}
       {{- if .Values.edgex.security.enabled }}
         command: ["/edgex-init/ready_to_run_wait_install.sh"]
-        args: ["/device-usb-camera", "-cp=consul.http://edgex-core-consul:8500", "--registry"]
+        args: ["/docker-entrypoint.sh", "-cp=consul.http://edgex-core-consul:8500", "--registry"]
       {{- end}}
         ports:
         - containerPort: {{.Values.edgex.port.device.usbcamera}}


### PR DESCRIPTION

  The device USB camera uses different executable like docker-entrypoint shell script for bootstrapper so update it for this case.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-examples/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)

## Testing Instructions
<!-- How can the reviewers test your change? -->