### PR TITLE
fix: camera mgmt docker build, secret names, and go mods

### DIFF
--- a/application-services/custom/camera-management/Dockerfile
+++ b/application-services/custom/camera-management/Dockerfile
@@ -15,10 +15,10 @@
 #
 
 #build stage
-ARG BASE=golang:1.18-alpine3.16
+ARG BASE=golang:1.20-alpine3.17
 FROM ${BASE} AS builder
 
-ARG ALPINE_PKG_BASE="make git gcc libc-dev libsodium-dev zeromq-dev"
+ARG ALPINE_PKG_BASE="make git gcc libc-dev libsodium-dev"
 ARG ALPINE_PKG_EXTRA=""
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
@@ -37,13 +37,13 @@ ARG MAKE="make build-app"
 RUN $MAKE
 
 #final stage
-FROM alpine:3.16
+FROM alpine:3.17
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-  copyright='Copyright (c) 2022: Intel'
+  copyright='Copyright (c) 2023: Intel'
 LABEL Name=app-camera-management Version=${VERSION}
 
 # dumb-init is required as security-bootstrapper uses it in the entrypoint script
-RUN apk add --update --no-cache ca-certificates zeromq dumb-init
+RUN apk add --update --no-cache ca-certificates dumb-init
 
 COPY --from=builder /app/LICENSE /LICENSE
 COPY --from=builder /app/res/ /res/
@@ -53,4 +53,4 @@ COPY --from=builder /app/web-ui/dist /web-ui/dist
 EXPOSE 59750
 
 ENTRYPOINT ["/app-camera-management"]
-CMD ["-cp=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res"]
+CMD ["--cp=consul.http://edgex-core-consul:8500", "--registry"]

--- a/application-services/custom/camera-management/README.md
+++ b/application-services/custom/camera-management/README.md
@@ -139,15 +139,7 @@ cd edgex-examples/application-services/custom/camera-management
 # Run this once to download edge-video-analytics into the edge-video-analytics sub-folder, 
 # download models, and patch pipelines
 make install-edge-video-analytics
-
-# Run the EVAM services (in another terminal)
-make run-edge-video-analytics
-# ...
-# Leave this running
 ```
-
-> **Note**: If you press `Ctrl-C` it will stop the EVAM services. If you then run `make stop-edge-video-analytics`,
-> it will also remove the containers and free up the port mappings.
 
 ### 3. Build and run the example application service
 
@@ -161,8 +153,8 @@ make run-edge-video-analytics
 
    ```yaml
   InsecureSecrets:
-     onvifCredentials:
-        SecretName: onvifAuth
+     onvifauth:
+        SecretName: onvifauth
         SecretData:
            username: "<username>"
            password: "<password>"
@@ -183,8 +175,8 @@ Option 1: Modify the [res/configuration.yaml](res/configuration.yaml) file
 
    ```yaml
   InsecureSecrets:
-     usbCredentials:
-        SecretName: rtspAuth
+     rtspauth:
+        SecretName: rtspauth
         SecretData:
            username: "<username>"
            password: "<password>"
@@ -215,12 +207,14 @@ cd edgex-examples/application-services/custom/camera-management
 ```
 
 ```shell
-# Build the app. 
-make build-app
+# Build the docker image. 
+make docker
 
-# Run the app.
-make run-app
+# Start the docker compose services in the background for both EVAM and Camera Management App
+docker compose up -d
 ```
+
+> **Note**: If you would like to view the logs for these services, you can use `docker compose logs -f`. To stop the services, use `docker compose down`.
 
 ## Using the App
 

--- a/application-services/custom/camera-management/appcamera/app.go
+++ b/application-services/custom/camera-management/appcamera/app.go
@@ -56,7 +56,7 @@ func (app *CameraManagementApp) Run() error {
 		}
 	}
 	if err != nil {
-		app.lc.Errorf("Unable to query EVAM pipeline statuses after %d tries. .")
+		app.lc.Errorf("Unable to query EVAM pipeline statuses after %d tries.", maxRetries)
 		return err // exit. we do not want to run if evam is not accessible
 	}
 

--- a/application-services/custom/camera-management/appcamera/commands.go
+++ b/application-services/custom/camera-management/appcamera/commands.go
@@ -8,6 +8,7 @@ package appcamera
 import (
 	"context"
 	"fmt"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 
 	"github.com/IOTechSystems/onvif/device"
 	"github.com/IOTechSystems/onvif/media"
@@ -15,7 +16,6 @@ import (
 	"github.com/IOTechSystems/onvif/xsd/onvif"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	dtosCommon "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 func (app *CameraManagementApp) getImageFormats(deviceName string) (interface{}, error) {
 	resp, err := app.issueGetCommand(context.Background(), deviceName, usbImageFormatsCommand)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to issue get ImageFormats command")
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to issue get ImageFormats command", err)
 	}
 	return resp.Event.Readings[0].ObjectValue, nil
 }
@@ -80,7 +80,7 @@ func (app *CameraManagementApp) getCameraFeatures(deviceName string) (CameraFeat
 		features.CameraType = Onvif
 		caps, err := app.getCapabilities(deviceName)
 		if err != nil {
-			return CameraFeatures{}, errors.Wrapf(err, "unable to get device capabilities")
+			return CameraFeatures{}, errors.NewCommonEdgeX(errors.KindServerError, "unable to get device capabilities", err)
 		}
 		if caps.Capabilities.PTZ.XAddr != "" {
 			features.PTZ = true
@@ -193,8 +193,8 @@ func (app *CameraManagementApp) getAllDevices() ([]dtos.Device, error) {
 	}
 
 	if len(devices) <= 0 {
-		return nil, errors.Errorf("no devices registered yet for the device services %s or %s",
-			app.config.AppCustom.OnvifDeviceServiceName, app.config.AppCustom.USBDeviceServiceName)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("no devices registered yet for the device services %s or %s",
+			app.config.AppCustom.OnvifDeviceServiceName, app.config.AppCustom.USBDeviceServiceName), nil)
 	}
 
 	return devices, nil

--- a/application-services/custom/camera-management/appcamera/credentials.go
+++ b/application-services/custom/camera-management/appcamera/credentials.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	rtspAuth  = "rtspAuth"
-	onvifAuth = "onvifAuth"
+	rtspauth  = "rtspauth"
+	onvifauth = "onvifauth"
 )
 
 // tryGetCredentials will attempt one time to get the camera credentials from the

--- a/application-services/custom/camera-management/appcamera/routes.go
+++ b/application-services/custom/camera-management/appcamera/routes.go
@@ -7,6 +7,7 @@ package appcamera
 
 import (
 	"fmt"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"net/http"
 	"path"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -117,7 +117,7 @@ func (app *CameraManagementApp) addRoutes() error {
 
 func (app *CameraManagementApp) addRoute(path, method string, f http.HandlerFunc) error {
 	if err := app.service.AddRoute(path, f, method); err != nil {
-		return errors.Wrapf(err, "failed to add route, path=%s, method=%s", path, method)
+		return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to add route, path=%s, method=%s", path, method), err)
 	}
 	return nil
 }

--- a/application-services/custom/camera-management/appcamera/util.go
+++ b/application-services/custom/camera-management/appcamera/util.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"io"
 	"net/http"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/responses"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -39,12 +39,12 @@ func (app *CameraManagementApp) parseResponse(commandName string, event *respons
 	val := event.Event.Readings[0].ObjectValue
 	js, err := json.Marshal(val)
 	if err != nil {
-		return errors.Wrapf(err, "failed to marshal %s object value as json object", commandName)
+		return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to marshal %s object value as json object", commandName), err)
 	}
 
 	err = json.Unmarshal(js, response)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarhal %s json object to response type %T", commandName, response)
+		return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to unmarhal %s json object to response type %T", commandName, response), err)
 	}
 
 	return nil
@@ -55,7 +55,7 @@ func (app *CameraManagementApp) issueGetCommandWithJsonForResponse(ctx context.C
 
 	event, err := app.issueGetCommandWithJson(ctx, deviceName, commandName, jsonValue)
 	if err != nil {
-		return errors.Wrapf(err, "failed to issue get command %s for device %s", commandName, deviceName)
+		return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to issue get command %s for device %s", commandName, deviceName), err)
 	}
 	return app.parseResponse(commandName, event, response)
 }
@@ -69,7 +69,7 @@ func (app *CameraManagementApp) issueGetCommandForResponse(ctx context.Context, 
 
 	event, err := app.issueGetCommand(ctx, deviceName, commandName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to issue get command %s for device %s", commandName, deviceName)
+		return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to issue get command %s for device %s", commandName, deviceName), err)
 	}
 	return app.parseResponse(commandName, event, response)
 }

--- a/application-services/custom/camera-management/docker-compose.yml
+++ b/application-services/custom/camera-management/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: "3"
+version: '3.7'
 
 networks:
   edgex_edgex-network:
@@ -22,9 +22,31 @@ networks:
     driver: "bridge"
 
 services:
-  edge_video_analytics_microservice:
+  edgex-app-camera-management:
+    image: edgexfoundry/app-camera-management:0.0.0-dev
+    hostname: edgex-app-camera-management
+    container_name: edgex-app-camera-management
+    networks:
+      - edgex_edgex-network
+    environment:
+      EDGEX_SECURITY_SECRET_STORE: "false"
+      SERVICE_HOST: edgex-app-camera-management
+      SERVICE_SERVERBINDADDR: "0.0.0.0"
+      APPCUSTOM_EVAMBASEURL: "http://edgex-video-analytics:8080"
+    read_only: true
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    depends_on:
+      edgex-video-analytics:
+        condition: service_started
+    ports:
+      - '59750:59750/tcp'
+
+  edgex-video-analytics:
     image: intel/edge_video_analytics_microservice:0.7.2
-    hostname: edge_video_analytics_microservice
+    hostname: edgex-video-analytics
+    container_name: edgex-video-analytics
     privileged: true
     entrypoint: ["./run.sh"]
     ports:
@@ -42,10 +64,13 @@ services:
       DETECTION_DEVICE: CPU
       CLASSIFICATION_DEVICE: CPU
       GST_DEBUG: "*:2,python*:4"
+    restart: always
+    security_opt:
+      - no-new-privileges:true
     volumes:
-      - "./pipelines/:/home/pipeline-server/pipelines/"
-      - "./models:/home/pipeline-server/models/"
-      - "./config.json:/home/pipeline-server/config.json"
+      - "./edge-video-analytics/pipelines/:/home/pipeline-server/pipelines/"
+      - "./edge-video-analytics/models:/home/pipeline-server/models/"
+      - "./edge-video-analytics/config.json:/home/pipeline-server/config.json"
     device_cgroup_rules:
       # Default run - device-cgroup-rule='c 189:* rmw'
       # NCS2 run - device-cgroup-rule='c 209:* rmw'

--- a/application-services/custom/camera-management/go.mod
+++ b/application-services/custom/camera-management/go.mod
@@ -1,11 +1,11 @@
 //
-// Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2022-2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
 module github.com/edgexfoundry/edgex-examples/application-services/custom/camera-management
 
-go 1.18
+go 1.20
 
 require (
 	github.com/IOTechSystems/onvif v0.1.6
@@ -13,7 +13,6 @@ require (
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.1
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0
 	github.com/gorilla/mux v1.8.0
-	github.com/pkg/errors v0.9.1
 )
 
 require (

--- a/application-services/custom/camera-management/go.sum
+++ b/application-services/custom/camera-management/go.sum
@@ -211,7 +211,6 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/application-services/custom/camera-management/res/configuration.yaml
+++ b/application-services/custom/camera-management/res/configuration.yaml
@@ -6,17 +6,17 @@ Writable:
     # NOTE: currently this solution is limited to supporting only 1 username/password combination
     #       for ALL cameras. In the future when then device-onvif-camera service is able to provide
     #       us with pre-authenticated uris, this can be removed.
-    onvifCredentials:
+    onvifauth:
       # Do not modify the SecretName, only add the username and password
-      SecretName: onvifAuth
+      SecretName: onvifauth
       SecretData:
         username: ""
         password: ""
 
     # TODO: Enter your device-usb-camera RTSP server credentials here.
-    usbCredentials:
+    rtspauth:
       # Do not modify the SecretName, only add the username and password
-      SecretName: rtspAuth
+      SecretName: rtspauth
       SecretData:
         username: ""
         password: ""


### PR DESCRIPTION
- Fixed the docker build for Camera Management App and make it work with docker compose.
- Fixed the naming inconsistencies with secrets in the yaml file and code. Now also matches rtspauth from the device-usb-camera service.
- Removed errors package from go.mod, to use EdgeX errors package, to match the device services.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-examples/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [N/A] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)

## Testing Instructions
<!-- How can the reviewers test your change? -->